### PR TITLE
Improved performance of push_back on evector.

### DIFF
--- a/Lilu/Headers/kern_util.hpp
+++ b/Lilu/Headers/kern_util.hpp
@@ -660,10 +660,11 @@ public:
 	 */
 	T *reserve(size_t num) {
 		if (rsvd < num) {
-			T *nPtr = static_cast<T *>(kern_os_realloc(ptr, num * sizeof(T)));
+            const size_t nsize = (num * 3 + 1) / 2;
+			T *nPtr = static_cast<T *>(kern_os_realloc(ptr, nsize * sizeof(T)));
 			if (nPtr) {
 				ptr = nPtr;
-				rsvd = num;
+				rsvd = nsize;
 			} else {
 				return nullptr;
 			}
@@ -738,7 +739,7 @@ public:
 	 */
 	void deinit() {
 		if (ptr) {
-			for (size_t i = 0; i < cnt; i++)
+			for (size_t i = 0; i < rsvd; i++)
 				deleter(ptr[i]);
 			kern_os_free(ptr);
 			ptr = nullptr;


### PR DESCRIPTION
Hi vit9696,

This strategy will largely improve the overall performance when we ```push_back``` new elements into evector by allocating more memory space before hand. In ```Lilu```, the ```reserve``` routine uses a trivial strategy that is growing the memory space per ```push_back```, however this will result in ```O(n)``` runtime complexity if we have n elements to insert into the evector, which is not a good choice. On the other hand,  ```g++``` will double size of the space of vector if reserved space is not enough, however, this is also not a good choice, the reason is as following. If realloc being called n times, then previous sum of all the reserved memory space will be less than the new reserved memory space 
![codecogseqn](https://user-images.githubusercontent.com/11594858/46595093-68fe3800-ca9c-11e8-9e74-2b0f2c5d07ba.gif)
where ```a``` is the size of a given element, this makes vector cache-unfriendly and memory manager unfriendly. A more detailed analysis can be found [here](https://github.com/syscl/Algorithm/blob/master/Memory/docs/MemoryStrategy.pdf). To sum up, we can choose to expand of the reserved space to 1.5 times of the original space, this can give us two benefits on ```evector```:

- Way much less realloc invokes from O(n) to O(log (n)) i.e. O(log (n)) amortized cost for push_back instead of O(n) as previous ```evector``` implementation
- Makes ```evector``` cache-friendly and memory manager friendly

I wish this could make ```Lilu```  faster than ever.

syscl
