### PR TITLE
Fix problem when wrong device is getting marked as HDEF on AMD.

### DIFF
--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -227,9 +227,13 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 								v.video = pciobj;
 								v.vendor = pcivendor;
 							} else if (pcicode == WIOKit::ClassCode::HDADevice || pcicode == WIOKit::ClassCode::HDAMmDevice) {
-								DBGLOG("dev", "found audio device %s at %s by %04X",
-									   safeString(pciobj->getName()), safeString(name), pcivendor);
-								v.audio = pciobj;
+								if(pcivendor == WIOKit::VendorID::AMDZEN || pcivendor == WIOKit::VendorID::ATIAMD) {
+									DBGLOG("dev", "found audio device %s at %s by %04X",
+										   safeString(pciobj->getName()), safeString(name), pcivendor);
+									v.audio = pciobj;
+								} else {
+									DBGLOG("dev", "skipping false audio device %s at %s by %04X",safeString(pciobj->getName()), safeString(name), pcivendor);
+								}
 							}
 						}
 					}


### PR DESCRIPTION
In some cases it gets GPU HDMI output as HDEF on AMD instead actual sound card. It happens because while enumerating it finds gpu before sound cart. Then it gets passed trough audioBuiltinAnalog to AppleALC, and AppleALC itself does not try to do further enumeration / search for sound card.

Since AppleALC.kext use some another way to activate sound on video card outputs, it seems enough for me to patch it in this simple way. If this would broke something, I would do another version of this patch.