### PR TITLE
Make possible to set external workLoop for plugin class.

### DIFF
--- a/Lilu/Headers/plugin_start.hpp
+++ b/Lilu/Headers/plugin_start.hpp
@@ -44,6 +44,13 @@ public:
 	IOService *probe(IOService *provider, SInt32 *score) override;
 	bool start(IOService *provider) override;
 	void stop(IOService *provider) override;
+	IOWorkLoop *getWorkLoop() const override {
+		return workLoop;
+	}
+	void setWorkLoop(IOWorkLoop *_workLoop) { workLoop = _workLoop; }
+	
+public:
+	IOWorkLoop *workLoop {nullptr};
 };
 
 extern PRODUCT_NAME *ADDPR(selfInstance);

--- a/Lilu/Library/plugin_start.cpp
+++ b/Lilu/Library/plugin_start.cpp
@@ -9,6 +9,8 @@
 #include <Headers/kern_api.hpp>
 #include <Headers/kern_util.hpp>
 
+#include <IOKit/IOWorkLoop.h>
+
 #ifndef LILU_CUSTOM_KMOD_INIT
 bool ADDPR(startSuccess) = false;
 #else


### PR DESCRIPTION
In some plugins we need timers. For example, it is not a good idea to call gIOCatalogue->startMatching in processKext or processKernel. Would be much better to postpone this action.

Lilu implements plugin IOService class anyway, so why don't use this class for timers? 
Usage example:

```
			if (!matchingTimer) {
				if (!ADDPR(selfInstance)->getWorkLoop())
					ADDPR(selfInstance)->setWorkLoop(IOWorkLoop::workLoop());
				
				if (ADDPR(selfInstance)->getWorkLoop()) {
					matchingTimer = IOTimerEventSource::timerEventSource(ADDPR(selfInstance),
					[](OSObject *owner, IOTimerEventSource *) {
						callbackBRCMFX->startMatching();
					});
					
					if (!matchingTimer)
						SYSLOG("BRCMFX", "timerEventSource failed");
					else
						ADDPR(selfInstance)->getWorkLoop()->addEventSource(matchingTimer);
				}
				else
					SYSLOG("BRCMFX", "IOService instance does not have workLoop");
			}
			if (matchingTimer)
				matchingTimer->setTimeoutMS(1000);
```