### PR TITLE
Add a new API to solve mutliple symbols in one shot and more

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 Lilu Changelog
 ==============
+#### v1.4.9
+- Added the PCI GMCH Graphics Control register definition. (by 0xFireWolf)
+- Added a new API to solve multiple symbols in one shot conveniently. (by 0xFireWolf)
+- Added a new `RouteRequest` constructor to work with function pointers without additional type castings. (by 0xFireWolf)
+
 #### v1.4.8
 - Added MacKernelSDK with Xcode 12 compatibility
 - Removed `kern_atomic.hpp` due to MacKernelSDK implementation

--- a/Lilu/Headers/kern_iokit.hpp
+++ b/Lilu/Headers/kern_iokit.hpp
@@ -197,7 +197,8 @@ namespace WIOKit {
 		kIOPCIConfigInterruptLine           = 0x3C,
 		kIOPCIConfigInterruptPin            = 0x3D,
 		kIOPCIConfigMinimumGrant            = 0x3E,
-		kIOPCIConfigMaximumLatency          = 0x3F
+		kIOPCIConfigMaximumLatency          = 0x3F,
+		kIOPCIConfigGraphicsControl         = 0x50
 	};
 
 	/**

--- a/Lilu/Headers/kern_patcher.hpp
+++ b/Lilu/Headers/kern_patcher.hpp
@@ -470,6 +470,16 @@ public:
 		template <typename T>
 		RouteRequest(const char *s, T t, mach_vm_address_t &o) :
 			symbol(s), to(reinterpret_cast<mach_vm_address_t>(t)), org(&o) { }
+		
+		/**
+		 *  Construct RouteRequest for wrapping a function
+		 *  @param s  symbol to lookup
+		 *  @param t  destination address
+		 *  @param o  trampoline storage to the original symbol
+		 */
+		template <typename T, typename O>
+		RouteRequest(const char *s, T t, O &o) :
+			RouteRequest(s, t, reinterpret_cast<mach_vm_address_t&>(o)) { }
 
 		/**
 		 *  Construct RouteRequest for routing a function

--- a/Lilu/Headers/kern_patcher.hpp
+++ b/Lilu/Headers/kern_patcher.hpp
@@ -256,16 +256,19 @@ public:
 	 *  @param start     start address range
 	 *  @param size      address range size
 	 *  @param crash     kernel panic on invalid non-zero address
+	 *  @param force     continue on first error
 	 *
 	 *  @return false if at least one symbol cannot be solved.
 	 */
-	inline bool solveMultiple(size_t id, SolveRequest *requests, size_t num, mach_vm_address_t start, size_t size, bool crash=false) {
+	inline bool solveMultiple(size_t id, SolveRequest *requests, size_t num, mach_vm_address_t start, size_t size, bool crash=false, bool force=false) {
 		for (size_t index = 0; index < num; index++) {
 			auto result = solveSymbol(id, requests[index].symbol, start, size, crash);
-			if (result)
+			if (result) {
 				*requests[index].address = result;
-			else
-				return false;
+			} else {
+				clearError();
+				if (!force) return false;
+			}
 		}
 		return true;
 	}
@@ -278,12 +281,13 @@ public:
 	 *  @param start     start address range
 	 *  @param size      address range size
 	 *  @param crash     kernel panic on invalid non-zero address
+	 *  @param force     continue on first error
 	 *
 	 *  @return false if at least one symbol cannot be solved.
 	 */
 	template <size_t N>
-	inline bool solveMultiple(size_t id, SolveRequest (&requests)[N], mach_vm_address_t start, size_t size, bool crash=false) {
-		return solveMultiple(id, requests, N, start, size, crash);
+	inline bool solveMultiple(size_t id, SolveRequest (&requests)[N], mach_vm_address_t start, size_t size, bool crash=false, bool force=false) {
+		return solveMultiple(id, requests, N, start, size, crash, force);
 	}
 
 	/**


### PR DESCRIPTION
**This pull request contains 3 changes.**

#### Abstract:

1. Add a new API `solveMultiple()` to resolve multiple symbols with one single function call. A new structure `SolveRequest` is added to encapsulate a symbol solve request. The functionality is similar to the existing `routeMultiple()` API.

2. Add a new constructor to `RouteRequest` to work with function pointers without additional type castings. Previously, if one wants to wrap a function `F`, the type of the variable that stores the original function should be `mach_vm_address_t`, otherwise one needs to convert the function pointer type to `mach_vm_address_t&`. The new constructor does the type casting behind the scene and thus makes it convenient for developers.

```c++
// Previous: Usage Example 1
mach_vm_address_t orgFunction {0};
RouteRequest("symbol", wrapperFunction, orgFunction);
// When the original function is called, developers must cast it again.

// Previous: Usage Example 2
IOReturn (*orgFunction)(UInt32 arg0) {nullptr};
RouteRequest("symbol", wrapperFunction, reinterpret_cast<mach_vm_address_t&>(orgFunction));

// Now: Nice and clean; Easy to read.
IOReturn (*orgFunction)(UInt32 arg0) {nullptr};
RouteRequest("symbol", wrapperFunction, orgFunction);
```

3. Add the GMCH Graphics Control register definition to WIOKit. This register stores the DVMT pre-allocated memory set in the BIOS and is needed by WhateverGreen.