### PR TITLE
fix for some AMD Zen platforms

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 Lilu Changelog
 ==============
+#### v1.5.2
+- Fixed AZAL recognition as GPU audio on certain AMD platforms (thx to wkpark)
+
 #### v1.5.1
 - Added `lilu_os_memmem` and `lilu_os_memchr` APIs
 - Added `getSharedCachePath` API to obtain current cache path

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -256,7 +256,7 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 
 					pciiterator->release();
 
-					if (v.video) {
+					if (((v.audio && strcmp(v.audio->getName(), "AZAL") != 0) || !v.audio) && v.video) { // check for some AMDZEN cases
 						DBGLOG_COND(v.audio, "dev", "marking audio device as HDAU at %s", safeString(v.audio->getName()));
 						if (!videoExternal.push_back(v))
 							SYSLOG("dev", "failed to push video gpu");

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -256,7 +256,10 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 
 					pciiterator->release();
 
-					if (((v.audio && strcmp(v.audio->getName(), "AZAL") != 0) || !v.audio) && v.video) { // check for some AMDZEN cases
+					// AZAL audio devices cannot be descrete GPU devices.
+					// On several AMD platforms there is an IGPU, which makes AZAL be recognised as a descrete GPU/HDA pair.
+					// REF: https://github.com/acidanthera/Lilu/pull/65
+					if (((v.audio && strcmp(v.audio->getName(), "AZAL") != 0) || !v.audio) && v.video) {
 						DBGLOG_COND(v.audio, "dev", "marking audio device as HDAU at %s", safeString(v.audio->getName()));
 						if (!videoExternal.push_back(v))
 							SYSLOG("dev", "failed to push video gpu");


### PR DESCRIPTION
This is a quick hack to fix this case. (like as Asrok B450M-Pro4-F board)
- audio(AZAL) and video are in the same pci-bridge. Lilu does not detect it correctly.

Note:
> According to the code, Lilu will try to find an audio device. There are two types of audio:
> 1. audio with graphic (identified by v.video)
> 2. audio builtin onboard (assigned to variable `audioBuiltinAnalog`)
>
> from https://forums.unraid.net/topic/50191-video-guide-how-to-install-macos-mojave-or-high-sierra-as-a-vm/page/56/?tab=comments#comment-782474

Recent discussion:
- https://github.com/acidanthera/bugtracker/issues/296

gfxutil output with this fix.
```
% ./gfxutil -f HDEF
07:00.6 1022:15e3 /PCI0@0/GP17@8,1/HDEF@0,6 = PciRoot(0x0)/Pci(0x8,0x1)/Pci(0x0,0x6)
```

Screenshot with this patch.
![image](https://user-images.githubusercontent.com/232347/108457987-0269c580-72b7-11eb-9fd6-96d2ee87f136.png)
