### PR TITLE
Added a variant of `KernelPatcher::findAndReplace` that requires buffers to have the same length.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 Lilu Changelog
 ==============
+#### v1.5.5
+- Added a variant of `KernelPatcher::findAndReplace` that requires both `find` and `replace` buffers to have the same length.
+
 #### v1.5.4
 - Allow loading on macOS 12 without `-lilubetaall` (With adapted for macOS 12 plug-ins)
 - Added guarding for address slot usage to avoid potential kernel routing overflow

--- a/KnownPlugins.md
+++ b/KnownPlugins.md
@@ -24,6 +24,7 @@ Please note that improperly written immature plugins will not be listed there.
 [NVMeFix](https://github.com/acidanthera/NVMeFix) | Improved power management for generic NVMe SSDs
 [OpcodeEmulator](https://www.insanelymac.com/forum/topic/329704-opcode-emulator-opemu-plug-in-project/) | Intel Haswell Pentium / Celeron Series Or older processor expansion instruction set Emulation
 [RestrictEvents](https://github.com/acidanthera/RestrictEvents) | Blocking unwanted processes causing compatibility issues on different hardware
+[RealtekCardReaderFriend](https://github.com/0xFireWolf/RealtekCardReaderFriend) | Recognize Realtek card readers as native ones
 [RTCMemoryFixup](https://github.com/acidanthera/RTCMemoryFixup) | Offsets in CMOS (RTC) memory emulation
 [FeatureUnlock](https://github.com/acidanthera/FeatureUnlock) | Enabling Sidecar support and other
 [SystemProfilerMemoryFixup](https://github.com/Goldfish64/SystemProfilerMemoryFixup) | Show memory tab on MacBook models with soldered RAM

--- a/Lilu/Headers/kern_patcher.hpp
+++ b/Lilu/Headers/kern_patcher.hpp
@@ -613,6 +613,14 @@ public:
 
 		return false;
 	}
+	
+	/**
+	 *  Simple find and replace in kernel memory but require both `find` and `replace` buffers to have the same length
+	 */
+	template <size_t N>
+	static inline bool findAndReplace(void *data, size_t dataSize, const uint8_t (&find)[N], const uint8_t (&replace)[N]) {
+		return findAndReplace(data, dataSize, find, N, replace, N);
+	}
 
 private:
 	/**


### PR DESCRIPTION
I was reading the code in the `FeatureUnlock` repo to understand the new way to patch user processes and found that it would be convenient to let the compiler to check the buffer length automatically. 

With this variant, we no longer need to write a bunch of `static_assert()` to ensure that both `find` and `replace` buffers have the same length.

Thank you.

-- FireWolf