### PR TITLE
Add kern_fwmgr for abstract firmware management

### DIFF
--- a/Lilu.xcodeproj/project.pbxproj
+++ b/Lilu.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		419163CC268FEC5900E58711 /* hde32.h in Headers */ = {isa = PBXBuildFile; fileRef = 419163C9268FEC5800E58711 /* hde32.h */; };
 		419163CD268FEC5900E58711 /* hde32.c in Sources */ = {isa = PBXBuildFile; fileRef = 419163CA268FEC5900E58711 /* hde32.c */; };
 		6F86FA742526419900D37571 /* kern_version.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 6F86FA732526419900D37571 /* kern_version.hpp */; };
+		BCA242A32734D72A008E14A0 /* kern_fwmgr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCA242A22734D72A008E14A0 /* kern_fwmgr.cpp */; };
 		CE1096261F22876B00B623FC /* umm_malloc.c in Sources */ = {isa = PBXBuildFile; fileRef = CE10961E1F22876B00B623FC /* umm_malloc.c */; };
 		CE1096271F22876B00B623FC /* umm_malloc.h in Headers */ = {isa = PBXBuildFile; fileRef = CE10961F1F22876B00B623FC /* umm_malloc.h */; };
 		CE2687F5213BC02900E17BDD /* kern_ubsan.c in Sources */ = {isa = PBXBuildFile; fileRef = CE2687F4213BC02900E17BDD /* kern_ubsan.c */; };
@@ -150,6 +151,9 @@
 		419163C9268FEC5800E58711 /* hde32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hde32.h; sourceTree = "<group>"; };
 		419163CA268FEC5900E58711 /* hde32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hde32.c; sourceTree = "<group>"; };
 		6F86FA732526419900D37571 /* kern_version.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = kern_version.hpp; sourceTree = "<group>"; };
+		BCA242A02734D687008E14A0 /* MacKernelSDK */ = {isa = PBXFileReference; lastKnownFileType = folder; path = MacKernelSDK; sourceTree = "<group>"; };
+		BCA242A12734D6AE008E14A0 /* kern_fwmgr.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = kern_fwmgr.hpp; sourceTree = "<group>"; };
+		BCA242A22734D72A008E14A0 /* kern_fwmgr.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = kern_fwmgr.cpp; path = Lilu/Sources/kern_fwmgr.cpp; sourceTree = "<group>"; };
 		CE10961E1F22876B00B623FC /* umm_malloc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = umm_malloc.c; sourceTree = "<group>"; };
 		CE10961F1F22876B00B623FC /* umm_malloc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = umm_malloc.h; sourceTree = "<group>"; };
 		CE22EA372037A4BB002A88A5 /* kern_cpu.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = kern_cpu.hpp; sourceTree = "<group>"; };
@@ -309,6 +313,7 @@
 		1C748C1D1C21952C0024EED2 = {
 			isa = PBXGroup;
 			children = (
+				BCA242A02734D687008E14A0 /* MacKernelSDK */,
 				CE2E7BCB1E2C6DCA009AC62A /* PrivateHeaders */,
 				CE2E7B861E2C6A73009AC62A /* Headers */,
 				CE2E7BE21E2C73B1009AC62A /* Library */,
@@ -366,6 +371,7 @@
 				CE2E7B921E2C6A73009AC62A /* kern_util.hpp */,
 				6F86FA732526419900D37571 /* kern_version.hpp */,
 				CE405ED41E4A005400AA0B3D /* plugin_start.hpp */,
+				BCA242A12734D6AE008E14A0 /* kern_fwmgr.hpp */,
 			);
 			name = Headers;
 			path = Lilu/Headers;
@@ -397,6 +403,7 @@
 				CE2687F4213BC02900E17BDD /* kern_ubsan.c */,
 				CE2E7BAD1E2C6BAA009AC62A /* kern_user.cpp */,
 				CE2E7BAE1E2C6BAA009AC62A /* kern_util.cpp */,
+				BCA242A22734D72A008E14A0 /* kern_fwmgr.cpp */,
 			);
 			name = Sources;
 			sourceTree = "<group>";
@@ -633,6 +640,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE2E7BB51E2C6BAA009AC62A /* kern_policy.cpp in Sources */,
+				BCA242A32734D72A008E14A0 /* kern_fwmgr.cpp in Sources */,
 				1C3E7B261C84B65400A6448A /* X86DisassemblerDecoder.c in Sources */,
 				CE2E7BB41E2C6BAA009AC62A /* kern_patcher.cpp in Sources */,
 				CE335AE52097444900C60A5F /* kern_rtc.cpp in Sources */,

--- a/Lilu/Headers/kern_fwmgr.hpp
+++ b/Lilu/Headers/kern_fwmgr.hpp
@@ -1,0 +1,74 @@
+//
+//  kern_fwmgr.h
+//  Lilu
+//
+//  Copyright © 2021 cjiang. All rights reserved.
+//
+
+#ifndef kern_fwmgr_hpp
+#define kern_fwmgr_hpp
+
+#include <IOKit/IOService.h>
+#include <IOKit/IOLib.h>
+#include <libkern/OSKextLib.h>
+
+typedef struct FirmwareDescriptor
+{
+	char * name;
+	UInt8 * firmwareData;
+	UInt32 firmwareSize;
+} FirmwareDescriptor;
+
+class FirmwareManager : public IOService
+{
+	OSDeclareDefaultStructors(FirmwareManager)
+
+	struct ResourceCallbackContext
+	{
+		FirmwareManager * me;
+		OSData * firmware;
+	};
+
+public:
+	/*! @function withName
+	 *   @abstract Creates an FirmwareManager instance with the name of the firmware in that is requested.
+	 *   @discussion After creating the instance, the function calls setFirmwareWithName to set the firmware.
+	 *   @param name The name of the requested firmware.
+	 *   @param firmwareList A list that consists of all possible firmware candidates.
+	 *   @param numFirmwares The number of firmwares in firmwareList.
+	 *   @result If the operation is successful, the instance created is returned. */
+
+	static FirmwareManager * withName(char * name, FirmwareDescriptor * firmwareList, int numFirmwares);
+
+	virtual IOReturn setFirmwareWithName(char * name, FirmwareDescriptor * firmwareCandidates, int numFirmwares);
+
+	/*! @function withDescriptor
+	 *   @abstract Creates an FirmwareManager instance with a firmware descriptor.
+	 *   @discussion After creating the instance, the function calls setFirmwareWithDescriptor to set the firmware.
+	 *   @param firmware The firmware descriptor upon which the instance will be generated.
+	 *   @result If the operation is successful, the instance created is returned. */
+
+	static FirmwareManager * withDescriptor(FirmwareDescriptor firmware);
+
+	virtual IOReturn setFirmwareWithDescriptor(FirmwareDescriptor firmware);
+
+	virtual bool init( OSDictionary * dictionary = NULL ) APPLE_KEXT_OVERRIDE;
+	virtual void free() APPLE_KEXT_OVERRIDE;
+
+	virtual IOReturn removeFirmware();
+
+	virtual OSData * getFirmwareUncompressed();
+	virtual char * getFirmwareName();
+
+protected:
+	virtual int decompressFirmware(OSData * firmware);
+	virtual bool isFirmwareCompressed(OSData * firmware);
+
+protected:
+	char * mFirmwareName;
+	IOLock * mUncompressedFirmwareLock;
+	OSData * mUncompressedFirmwareData;
+	IOLock * mCompletionLock;
+};
+
+#endif /* kern_fwmgr_hpp */

--- a/Lilu/Sources/kern_fwmgr.cpp
+++ b/Lilu/Sources/kern_fwmgr.cpp
@@ -44,8 +44,14 @@ extern "C"
 	}
 }
 
+#define super IOService
+OSDefineMetaClassAndStructors(FirmwareManager, super)
+
 bool FirmwareManager::init(OSDictionary * dictionary)
 {
+	if ( !super::init() )
+		return false;
+
 	mFirmwareName = NULL;
 	mUncompressedFirmwareLock = IOLockAlloc();
 	mUncompressedFirmwareData = NULL;
@@ -56,6 +62,7 @@ void FirmwareManager::free()
 {
 	removeFirmware();
 	IOLockFree(mUncompressedFirmwareLock);
+	super::free();
 }
 
 int FirmwareManager::decompressFirmware(OSData * firmware)

--- a/Lilu/Sources/kern_fwmgr.cpp
+++ b/Lilu/Sources/kern_fwmgr.cpp
@@ -1,0 +1,217 @@
+//
+//  kern_fwmgr.cpp
+//  Lilu
+//
+//  Copyright © 2021 cjiang. All rights reserved.
+//
+
+#include <Headers/kern_fwmgr.hpp>
+#include <libkern/zlib.h>
+
+extern "C"
+{
+	static void * zalloc(void * opaque, UInt32 items, UInt32 size);
+	static void zfree(void * opaque, void * ptr);
+
+	typedef struct z_mem
+	{
+		UInt32 allocSize;
+		UInt8 data[0];
+	} z_mem;
+
+	void * zalloc(void * opaque, UInt32 items, UInt32 size)
+	{
+	   void * result = NULL;
+	   z_mem * zmem = NULL;
+	   UInt32 allocSize =  items * size + sizeof(zmem);
+
+	   zmem = (z_mem *) IOMalloc(allocSize);
+
+	   if (zmem)
+	   {
+		   zmem->allocSize = allocSize;
+		   result = (void *) &(zmem->data);
+	   }
+
+	   return result;
+	}
+
+	void zfree(void * opaque, void * ptr)
+	{
+	   UInt32 * skipper = (UInt32 *) ptr - 1;
+	   z_mem * zmem = (z_mem *) skipper;
+	   IOFree((void *) zmem, zmem->allocSize);
+	}
+}
+
+bool FirmwareManager::init(OSDictionary * dictionary)
+{
+	mFirmwareName = NULL;
+	mUncompressedFirmwareLock = IOLockAlloc();
+	mUncompressedFirmwareData = NULL;
+	return true;
+}
+
+void FirmwareManager::free()
+{
+	removeFirmware();
+	IOLockFree(mUncompressedFirmwareLock);
+}
+
+int FirmwareManager::decompressFirmware(OSData * firmware)
+{
+	z_stream zstream;
+	int zlib_result;
+	void * buffer = NULL;
+	UInt32 bufferSize = 0;
+
+	if ( !isFirmwareCompressed(firmware) )
+	{
+		firmware->retain();
+		IOLockLock(mUncompressedFirmwareLock);
+		mUncompressedFirmwareData = firmware;
+		IOLockUnlock(mUncompressedFirmwareLock);
+		return Z_OK;
+	}
+
+	bufferSize = firmware->getLength() * 4;
+	buffer = IOMalloc(bufferSize);
+
+	bzero(&zstream, sizeof(zstream));
+	zstream.next_in   = (UInt8 *) firmware->getBytesNoCopy();
+	zstream.avail_in  = firmware->getLength();
+	zstream.next_out  = (UInt8 *) buffer;
+	zstream.avail_out = bufferSize;
+	zstream.zalloc    = zalloc;
+	zstream.zfree     = zfree;
+
+	zlib_result = inflateInit(&zstream);
+	if (zlib_result != Z_OK)
+	{
+		IOFree(buffer, bufferSize);
+		return zlib_result;
+	}
+
+	zlib_result = inflate(&zstream, Z_FINISH);
+	if (zlib_result == Z_STREAM_END || zlib_result == Z_OK)
+	{
+		IOLockLock(mUncompressedFirmwareLock);
+		mUncompressedFirmwareData = OSData::withBytes(buffer, (unsigned int) zstream.total_out);
+		IOLockUnlock(mUncompressedFirmwareLock);
+	}
+
+	inflateEnd(&zstream);
+	IOFree(buffer, bufferSize);
+
+	return zlib_result;
+}
+
+IOReturn FirmwareManager::setFirmwareWithName(char * name, FirmwareDescriptor * firmwareCandidates, int numFirmwares)
+{
+	OSData * fwData;
+
+	for (int i = 0; i < numFirmwares; ++i)
+	{
+		if (firmwareCandidates[i].name == name)
+		{
+			mFirmwareName = name;
+			fwData = OSData::withBytes(firmwareCandidates[i].firmwareData, firmwareCandidates[i].firmwareSize);
+			if ( isFirmwareCompressed(fwData) )
+			{
+				if ( !decompressFirmware(fwData) )
+				{
+					OSSafeReleaseNULL(fwData);
+					return kIOReturnSuccess;
+				}
+				OSSafeReleaseNULL(fwData);
+				return kIOReturnError;
+			}
+			IOLockLock(mUncompressedFirmwareLock);
+			mUncompressedFirmwareData = fwData;
+			IOLockUnlock(mUncompressedFirmwareLock);
+			return kIOReturnSuccess;
+		}
+	}
+	return kIOReturnUnsupported;
+}
+
+IOReturn FirmwareManager::removeFirmware()
+{
+	mFirmwareName = NULL;
+
+	IOLockLock(mUncompressedFirmwareLock);
+	OSSafeReleaseNULL(mUncompressedFirmwareData);
+	IOLockUnlock(mUncompressedFirmwareLock);
+	return kIOReturnSuccess;
+}
+
+OSData * FirmwareManager::getFirmwareUncompressed()
+{
+	return mUncompressedFirmwareData;
+}
+
+char * FirmwareManager::getFirmwareName()
+{
+	return mFirmwareName;
+}
+
+IOReturn FirmwareManager::setFirmwareWithDescriptor(FirmwareDescriptor firmware)
+{
+	OSData * fwData = OSData::withBytes(firmware.firmwareData, firmware.firmwareSize);
+	mFirmwareName = firmware.name;
+
+	if ( isFirmwareCompressed(fwData) )
+	{
+		if ( !decompressFirmware(fwData) )
+		{
+			OSSafeReleaseNULL(fwData);
+			return kIOReturnSuccess;
+		}
+		OSSafeReleaseNULL(fwData);
+		return kIOReturnError;
+	}
+
+	IOLockLock(mUncompressedFirmwareLock);
+	mUncompressedFirmwareData = fwData;
+	IOLockUnlock(mUncompressedFirmwareLock);
+	return kIOReturnSuccess;
+}
+
+bool FirmwareManager::isFirmwareCompressed(OSData * firmware)
+{
+	UInt16 * magic = (UInt16 *) firmware->getBytesNoCopy();
+
+	if ( *magic == 0x0178   // Zlib no compression
+	  || *magic == 0x9c78   // Zlib default compression
+	  || *magic == 0xda78 ) // Zlib maximum compression
+		return true;
+	return false;
+}
+
+FirmwareManager * FirmwareManager::withName(char * name, FirmwareDescriptor * firmwareList, int numFirmwares)
+{
+	FirmwareManager * me = OSTypeAlloc(FirmwareManager);
+
+	if ( !me )
+		return NULL;
+	if ( me->setFirmwareWithName(name, firmwareList, numFirmwares) )
+	{
+		OSSafeReleaseNULL(me);
+		return NULL;
+	}
+	return me;
+}
+
+FirmwareManager * FirmwareManager::withDescriptor(FirmwareDescriptor firmware)
+{
+	FirmwareManager * me = OSTypeAlloc(FirmwareManager);
+
+	if ( !me )
+		return NULL;
+	if ( me->setFirmwareWithDescriptor(firmware) )
+	{
+		OSSafeReleaseNULL(me);
+		return NULL;
+	}
+	return me;
+}


### PR DESCRIPTION
Greetings,
Firmware management is a common issue in driver development - a lot of kexts have to upload their devices' firmware to the system so that they could be properly supported. Due to the relatively large size of firmwares, developers would generally compress them and handle decompression in the driver. This module aims at providing generic support for firmware decompression and management - it maintains the various properties of a firmware and can decompress it upon initialization. A developer merely has to put such an instance in their software (namely among the driver class's many member variable) and it would be ready for use.
For now, only initialization from a "firmware list" is supported. This has to be created manually by the user, see [the sample script](https://github.com/AppleBluetooth/IntelBluetoothFamily/blob/main/fw_gen.py). I hope support for allocation from firmware files per se could come soon.
This is based off [OpenFirmwareManager](https://github.com/AppleBluetooth/OpenFirmwareManager) with slight changes - I believe it could expand Lilu's features even more and by merging it decrement the numbers of kexts required.
Sincere Regards