### PR TITLE
kern_user: Add Ventura pathing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@ Lilu Changelog
 ==============
 #### v1.6.1
 - Allow loading on macOS 13 without `-lilubetaall`
+- Added Ventura dyld shared cache pathing 
 
 #### v1.6.0
 - Dropped internal shared patcher instance grabbing API

--- a/Lilu/Headers/kern_user.hpp
+++ b/Lilu/Headers/kern_user.hpp
@@ -610,6 +610,26 @@ private:
 	 */
 	static constexpr const char *bigSurSharedCacheLegacy {"/System/Library/dyld/dyld_shared_cache_x86_64"};
 
+	/**
+	 *  DYLD shared cache map path on Haswell+ on Ventura
+	 */
+	static constexpr const char *venturaSharedCacheMapHaswell {"/System/Volumes/Preboot/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_x86_64h.map"};
+	
+	/**
+	 *  DYLD shared cache map path on older systems on Ventura
+	 */
+	static constexpr const char *venturaSharedCacheMapLegacy {"/System/Volumes/Preboot/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_x86_64.map"};
+
+	/**
+	 *  DYLD shared cache path on Haswell+ on Ventura
+	 */
+	static constexpr const char *venturaSharedCacheHaswell {"/System/Volumes/Preboot/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_x86_64h"};
+
+	/**
+	 *  DYLD shared cache path on older systems on Ventura
+	 */
+	static constexpr const char *venturaSharedCacheLegacy {"/System/Volumes/Preboot/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_x86_64"};
+
 };
 
 #endif /* kern_user_hpp */

--- a/Lilu/Sources/kern_user.cpp
+++ b/Lilu/Sources/kern_user.cpp
@@ -1152,15 +1152,18 @@ void UserPatcher::activate() {
 
 const char *UserPatcher::getSharedCachePath() {
 	bool isHaswell = BaseDeviceInfo::get().cpuHasAvx2;
-	if (getKernelVersion() >= KernelVersion::BigSur)
+	if (getKernelVersion() >= KernelVersion::Ventura)
+		return isHaswell ? venturaSharedCacheHaswell : venturaSharedCacheLegacy;
+	else if (getKernelVersion() >= KernelVersion::BigSur)
 		return isHaswell ? bigSurSharedCacheHaswell : bigSurSharedCacheLegacy;
 	return isHaswell ? sharedCacheHaswell : sharedCacheLegacy;
 }
 
 bool UserPatcher::matchSharedCachePath(const char *path) {
 	if (getKernelVersion() >= KernelVersion::BigSur) {
-		auto len = strlen(bigSurSharedCacheLegacy);
-		if (strncmp(path, bigSurSharedCacheLegacy, len) != 0)
+		auto dyld_path = getKernelVersion() >= KernelVersion::Ventura ? venturaSharedCacheLegacy : sharedCacheLegacy;
+		auto len = strlen(dyld_path);
+		if (strncmp(path, dyld_path, len) != 0)
 			return false;
 		path += len;
 	} else {


### PR DESCRIPTION
With macOS Ventura, Apple moved the dyld shared cache to the Preboot volume. This PR simply adds Ventura pathing to Preboot.

* Note: while Apple has removed non-AVX2.0 dyld caches on Intel, Apple Silicon installations still retain it due to the lack of AVX2.0 support in Rosetta

| Apple Silicon Preboot | `_cs_validate_page` pathing |
| :--- | :--- |
| <img width="600" alt="Screen Shot 2022-06-06 at 9 19 29 PM" src="https://user-images.githubusercontent.com/48863253/173136440-60b0e736-7a79-47a5-8862-d9536acfc476.png"> | <img width="600" alt="Screen Shot 2022-06-10 at 1 28 36 PM" src="https://user-images.githubusercontent.com/48863253/173136688-a3b971bf-95a4-4200-8860-c3f6306df127.png"> |

