### PR TITLE
Fix wrong KC segment name, thanks @mhaeuser

### DIFF
--- a/Lilu/Sources/kern_mach.cpp
+++ b/Lilu/Sources/kern_mach.cpp
@@ -828,7 +828,7 @@ kern_return_t MachInfo::kcGetRunningAddresses(mach_vm_address_t slide) {
 
 			if (loadCmd->cmd == LC_SEGMENT_64) {
 				segment_command_64 *segCmd = reinterpret_cast<segment_command_64 *>(loadCmd);
-				if (!strncmp(segCmd->segname, "__PRELINK_TEXT", sizeof(segCmd->segname))) {
+				if (!strncmp(segCmd->segname, "__TEXT_EXEC", sizeof(segCmd->segname))) {
 					inner = reinterpret_cast<mach_header_64 *>(segCmd->vmaddr);
 					break;
 				}


### PR DESCRIPTION
`__PRELINK_TEXT` was a deprecated marker segment that broke with macOS 13 b3; `__TEXT_EXEC` is the actual inner kernel segment