### PR TITLE
Utils: Add a new helper to modify the value of a struct member by its offset

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@ Lilu Changelog
 ==============
 #### v1.6.6
 - Fixed macOS 13+ installer detection regression in 1.6.5
+- Added a new helper to set the value of a struct member by its offset
 
 #### v1.6.5
 - Fixed macOS 13+ recovery and installer detection

--- a/Lilu/Headers/kern_util.hpp
+++ b/Lilu/Headers/kern_util.hpp
@@ -457,6 +457,18 @@ inline T &getMember(void *that, size_t off) {
 }
 
 /**
+ *  Modify struct member by its offset
+ *
+ *	@param that  pointer to struct
+ *	@param off   offset in bytes to the member
+ *	@param value the new value of the member at the given offset
+ */
+template <typename T>
+inline void setMember(void *that, size_t off, T value) {
+	*reinterpret_cast<T *>(static_cast<uint8_t *>(that) + off) = value;
+}
+
+/**
  *  Align value by align (page size by default)
  *
  *  @param size  value

--- a/Lilu/Headers/kern_util.hpp
+++ b/Lilu/Headers/kern_util.hpp
@@ -459,9 +459,9 @@ inline T &getMember(void *that, size_t off) {
 /**
  *  Modify struct member by its offset
  *
- *	@param that  pointer to struct
- *	@param off   offset in bytes to the member
- *	@param value the new value of the member at the given offset
+ *  @param that  pointer to struct
+ *  @param off   offset in bytes to the member
+ *  @param value the new value of the member at the given offset
  */
 template <typename T>
 inline void setMember(void *that, size_t off, T value) {


### PR DESCRIPTION
This helper is needed by WEG's new patch submodule (https://github.com/acidanthera/WhateverGreen/pull/113).