### PR TITLE
Added Raptor Lake C0 stepping model

### DIFF
--- a/Lilu/Headers/kern_cpu.hpp
+++ b/Lilu/Headers/kern_cpu.hpp
@@ -93,7 +93,8 @@ namespace CPUInfo {
 		CPU_MODEL_ROCKETLAKE_S   =  0xA7, /* desktop RocketLake */
 		CPU_MODEL_TIGERLAKE_U    =  0x8C,
 		CPU_MODEL_ALDERLAKE_S    =  0x97,
-		CPU_MODEL_RAPTORLAKE_S   =  0xB7,
+		CPU_MODEL_RAPTORLAKE_S   =  0xB7, /* Raptor Lake B0 stepping */
+		CPU_MODEL_RAPTORLAKE_HX  =  0xBF, /* Raptor Lake C0 stepping */
 	};
 
 	/**

--- a/Lilu/Sources/kern_cpu.cpp
+++ b/Lilu/Sources/kern_cpu.cpp
@@ -135,6 +135,7 @@ void CPUInfo::init() {
 				bdi.cpuGeneration = CpuGeneration::AlderLake;
 				break;
 			case CPU_MODEL_RAPTORLAKE_S:
+			case CPU_MODEL_RAPTORLAKE_HX:
 				bdi.cpuGeneration = CpuGeneration::RaptorLake;
 				break;
 			default:


### PR DESCRIPTION
Certain Raptor Lake SKUs may have a separate stepping and model ID: https://edc.intel.com/content/www/us/en/design/products/platforms/details/raptor-lake-s/13th-generation-core-processors-datasheet-volume-1-of-2/005/cpuid/

This should fix https://github.com/acidanthera/bugtracker/issues/2305.

I'm not sure about the `CPU_MODEL_RAPTORLAKE_HX` name, though. Feel free to suggest something else.