### PR TITLE
Fix the failure memory order argument to atomic_compare_exchange_strong_explicit

### DIFF
--- a/Lilu/Headers/kern_util.hpp
+++ b/Lilu/Headers/kern_util.hpp
@@ -709,7 +709,7 @@ public:
 		for (size_t i = 0; ptr == nullptr && i < N; i++) {
 			thread_t nullThread = nullptr;
 			if (atomic_compare_exchange_strong_explicit(&threads[i], &nullThread, currThread,
-				memory_order_acq_rel, memory_order_acq_rel))
+				memory_order_acq_rel, memory_order_acquire))
 				ptr = &values[i];
 		}
 


### PR DESCRIPTION
The failure memory order cannot be release or acq_rel. Clang since llvm/llvm-project@fed5644 diagnoses an invalid argument.