### PR TITLE
New request to merge LiluSequoia commits

### DIFF
--- a/Lilu/Headers/kern_util.hpp
+++ b/Lilu/Headers/kern_util.hpp
@@ -395,6 +395,7 @@ enum KernelVersion {
 	Monterey      = 21,
 	Ventura       = 22,
 	Sonoma        = 23,
+	Sequoia       = 24,
 };
 
 /**

--- a/Lilu/PrivateHeaders/kern_config.hpp
+++ b/Lilu/PrivateHeaders/kern_config.hpp
@@ -56,9 +56,9 @@ private:
 	static constexpr KernelVersion minKernel {KernelVersion::Tiger};
 
 	/**
-	 * Maxmimum supported kernel version
+	 * Maximum supported kernel version
 	 */
-	static constexpr KernelVersion maxKernel {KernelVersion::Sonoma};
+	static constexpr KernelVersion maxKernel {KernelVersion::Sequoia};
 
 	/**
 	 *  Set once the arguments are parsed

--- a/Lilu/Scripts/bootstrap.sh
+++ b/Lilu/Scripts/bootstrap.sh
@@ -19,7 +19,7 @@
 #  src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/Lilu/master/Lilu/Scripts/bootstrap.sh) && eval "$src" || exit 1
 #
 
-REPO_PATH="acidanthera/Lilu"
+REPO_PATH="AlfCraft07/LiluSequoia"
 SDK_PATH="Lilu.kext"
 SDK_CHECK_PATH="${SDK_PATH}/Contents/Resources/Headers/kern_api.hpp"
 


### PR DESCRIPTION
After the 1st request made by another user, I'm making another request to merge commits from repos of other users that made Lilu compatible for Sequoia. The absence of these commits makes the code good only until Sonoma, and is starting to block the release of Sequoia kexts like NootedRed, that was prepared for release and is ready but precluded from it as the outdated code makes compilation fail and the code cannot be pushed. Please fix ASAP.