### PR TITLE
Add proper AMD Integrated Graphics detection.

### DIFF
--- a/Lilu/Headers/kern_devinfo.hpp
+++ b/Lilu/Headers/kern_devinfo.hpp
@@ -246,6 +246,41 @@ private:
 	static constexpr uint32_t ConnectorLessCoffeeLakePlatformId5 {0x9BC50003};
 	static constexpr uint32_t ConnectorLessCoffeeLakePlatformId6 {0x9BC40003};
 
+	/**
+	 * Kaveri, and also catches the new Granite Ridge rDNA 2 iGPU.
+	 */
+	static constexpr uint32_t GenericAMDKvGr = 0x1300;
+
+	/**
+	 * Kabini, Mullins, Carrizo, Stoney Ridge, Wrestler.
+	 */
+	static constexpr uint32_t GenericAMDKbMlCzStnWr = 0x9800;
+
+	/**
+	 * Raven/Raven2, Picasso, Barcelo, Phoenix & Phoenix 2 (?)
+	 */
+	static constexpr uint32_t GenericAMDRvPcBcPhn = 0x1500;
+
+	/**
+	 * Renoir, Cezanne, Lucienne, Van Gogh, Rembrandt, Raphael.
+	 */
+	static constexpr uint32_t GenericAMDRnCznLcVghRmbRph = 0x1600;
+
+	/**
+	 * Trinity
+	 */
+	static constexpr uint32_t GenericAMDTrinity = 0x9900;
+
+	/**
+	 * Sumo & Sumo2?
+	 */
+	static constexpr uint32_t GenericAMDSumo = 0x9600;
+
+	/**
+	 * Phoenix.
+	 */
+	static constexpr uint32_t GenericAMDPhoenix2 = 0x1900;
+
 public:
 	/**
 	 *  Vesa framebuffer identifier

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -209,9 +209,14 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 					DBGLOG("dev", "found IGPU device %s", safeString(name));
 					videoBuiltin = obj;
 					requestedExternalSwitchOff |= videoBuiltin->getProperty(RequestedExternalSwitchOffName) != nullptr;
-				  } else if (vendor == WIOKit::VendorID::ATIAMD && (code == WIOKit::ClassCode::DisplayController || code == WIOKit::ClassCode::VGAController)) {
-					DBGLOG("dev", "found AMD iGPU device %s", safeString(name));
+			} else if (vendor == WIOKit::VendorID::ATIAMD && (code == WIOKit::ClassCode::DisplayController || code == WIOKit::ClassCode::VGAController)) {
+				uint32_t dev = 0;
+				WIOKit::getOSDataValue(obj, "device-id", dev);
+				dev = (dev & 0xFF00);
+				if ((dev == 0x1600 || dev == 1500) || (dev == 0x9800 || dev == 0x1300) || (dev == 0x9900 || dev == 0x9800) || dev == 0x9600) {
+					DBGLOG("dev", "found IGPU device %s", safeString(name));
 					videoBuiltin = obj;
+				}
 			} else if (code == WIOKit::ClassCode::HDADevice || code == WIOKit::ClassCode::HDAMmDevice) {
 				if (vendor == WIOKit::VendorID::Intel && name && (!strcmp(name, "HDAU") || !strcmp(name, "B0D3"))) {
 					DBGLOG("dev", "found HDAU device %s", safeString(name));

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -206,9 +206,9 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 				continue;
 
 			if (vendor == WIOKit::VendorID::Intel && (code == WIOKit::ClassCode::DisplayController || code == WIOKit::ClassCode::VGAController)) {
-					DBGLOG("dev", "found IGPU device %s", safeString(name));
-					videoBuiltin = obj;
-					requestedExternalSwitchOff |= videoBuiltin->getProperty(RequestedExternalSwitchOffName) != nullptr;
+				DBGLOG("dev", "found IGPU device %s", safeString(name));
+				videoBuiltin = obj;
+				requestedExternalSwitchOff |= videoBuiltin->getProperty(RequestedExternalSwitchOffName) != nullptr;
 			} else if (vendor == WIOKit::VendorID::ATIAMD && (code == WIOKit::ClassCode::DisplayController || code == WIOKit::ClassCode::VGAController)) {
 				uint32_t dev = 0;
 				WIOKit::getOSDataValue(obj, "device-id", dev);

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -213,7 +213,7 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 				uint32_t dev = 0;
 				WIOKit::getOSDataValue(obj, "device-id", dev);
 				dev = (dev & 0xFF00);
-				if ((dev == 0x1600 || dev == 1500) || (dev == 0x9800 || dev == 0x1300) || (dev == 0x9900 || dev == 0x9800) || dev == 0x9600) {
+				if ((dev == 0x1600 || dev == 1500) || (dev == 0x9800 || dev == 0x1300) || (dev == 0x9900 || dev == 0x9600)) {
 					DBGLOG("dev", "found IGPU device %s", safeString(name));
 					videoBuiltin = obj;
 				}

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -213,7 +213,7 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 				uint32_t dev = 0;
 				WIOKit::getOSDataValue(obj, "device-id", dev);
 				dev = (dev & 0xFF00);
-				if ((dev == 0x1600 || dev == 0x1500) || (dev == 0x9800 || dev == 0x1300) || (dev == 0x9900 || dev == 0x9600)) {
+				if ((dev == GenericAMDRnCznLcVghRmbRph || dev == GenericAMDRvPcBcPhn) || (dev == GenericAMDKbMlCzStnWr || dev == GenericAMDKvGr) || (dev == GenericAMDTrinity || dev == GenericAMDSumo) || dev == GenericAMDPhoenix2) {
 					DBGLOG("dev", "found IGPU device %s", safeString(name));
 					videoBuiltin = obj;
 				}

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -213,7 +213,7 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 				uint32_t dev = 0;
 				WIOKit::getOSDataValue(obj, "device-id", dev);
 				dev = (dev & 0xFF00);
-				if ((dev == 0x1600 || dev == 1500) || (dev == 0x9800 || dev == 0x1300) || (dev == 0x9900 || dev == 0x9600)) {
+				if ((dev == 0x1600 || dev == 0x1500) || (dev == 0x9800 || dev == 0x1300) || (dev == 0x9900 || dev == 0x9600)) {
 					DBGLOG("dev", "found IGPU device %s", safeString(name));
 					videoBuiltin = obj;
 				}

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -206,9 +206,12 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 				continue;
 
 			if (vendor == WIOKit::VendorID::Intel && (code == WIOKit::ClassCode::DisplayController || code == WIOKit::ClassCode::VGAController)) {
-				DBGLOG("dev", "found IGPU device %s", safeString(name));
-				videoBuiltin = obj;
-				requestedExternalSwitchOff |= videoBuiltin->getProperty(RequestedExternalSwitchOffName) != nullptr;
+					DBGLOG("dev", "found IGPU device %s", safeString(name));
+					videoBuiltin = obj;
+					requestedExternalSwitchOff |= videoBuiltin->getProperty(RequestedExternalSwitchOffName) != nullptr;
+				  } else if (vendor == WIOKit::VendorID::ATIAMD && (code == WIOKit::ClassCode::DisplayController || code == WIOKit::ClassCode::VGAController)) {
+					DBGLOG("dev", "found AMD iGPU device %s", safeString(name));
+					videoBuiltin = obj;
 			} else if (code == WIOKit::ClassCode::HDADevice || code == WIOKit::ClassCode::HDAMmDevice) {
 				if (vendor == WIOKit::VendorID::Intel && name && (!strcmp(name, "HDAU") || !strcmp(name, "B0D3"))) {
 					DBGLOG("dev", "found HDAU device %s", safeString(name));
@@ -272,10 +275,6 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 						// To distinguish the devices we use audio card presence as a marker.
 						DBGLOG("dev", "marking audio device as HDEF at %s", safeString(v.audio->getName()));
 						audioBuiltinAnalog = v.audio;
-						
-						if (v.video && v.vendor == WIOKit::VendorID::ATIAMD) {
-							videoBuiltin = v.video;
-						}
 					}
 				}
 			}


### PR DESCRIPTION
As the title implies, it's a proper implementation for detecting the iGPU device.

This targets more "_recent_" iGPUs.

Notably those of the:
- Trinity and Richland family,
- Kaveri/Kabini/Mullins Family,
- Carrizo and Stoney family,
- Mobile Vega ASIC family