### PR TITLE
Add AMD iGPU detection via device-id (V2)

### DIFF
--- a/Lilu/Headers/kern_devinfo.hpp
+++ b/Lilu/Headers/kern_devinfo.hpp
@@ -42,6 +42,13 @@ class DeviceInfo {
 	 *  @param obj  wait for (PCI) object publishing
 	 */
 	void awaitPublishing(IORegistryEntry *obj);
+	
+	/**
+	 *  Checks if an ATIAMD object is an AMD iGPU
+	 *
+	 *  @param obj  Object to run the check on.
+	 */
+	bool checkForAndSetAMDiGPU(IORegistryEntry *obj);
 
 public:
 	/**

--- a/Lilu/Headers/kern_devinfo.hpp
+++ b/Lilu/Headers/kern_devinfo.hpp
@@ -246,6 +246,41 @@ private:
 	static constexpr uint32_t ConnectorLessCoffeeLakePlatformId5 {0x9BC50003};
 	static constexpr uint32_t ConnectorLessCoffeeLakePlatformId6 {0x9BC40003};
 
+	/**
+	 * Kaveri, and also catches the new Granite Ridge rDNA 2 iGPU.
+	 */
+	static constexpr uint32_t GenericAMDKvGr = 0x1300;
+
+	/**
+	 * Kabini, Mullins, Carrizo, Stoney Ridge, Wrestler.
+	 */
+	static constexpr uint32_t GenericAMDKbMlCzStnWr = 0x9800;
+
+	/**
+	 * Raven/Raven2, Picasso, Barcelo, Phoenix & Phoenix 2 (?)
+	 */
+	static constexpr uint32_t GenericAMDRvPcBcPhn = 0x1500;
+
+	/**
+	 * Renoir, Cezanne, Lucienne, Van Gogh, Rembrandt, Raphael.
+	 */
+	static constexpr uint32_t GenericAMDRnCznLcVghRmbRph = 0x1600;
+
+	/**
+	 * Trinity
+	 */
+	static constexpr uint32_t GenericAMDTrinity = 0x9900;
+
+	/**
+	 * Sumo & Sumo2?
+	 */
+	static constexpr uint32_t GenericAMDSumo = 0x9600;
+
+	/**
+	 * Phoenix.
+	 */
+	static constexpr uint32_t GenericAMDPhoenix2 = 0x1900;
+
 public:
 	/**
 	 *  Vesa framebuffer identifier

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -209,9 +209,14 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 					DBGLOG("dev", "found IGPU device %s", safeString(name));
 					videoBuiltin = obj;
 					requestedExternalSwitchOff |= videoBuiltin->getProperty(RequestedExternalSwitchOffName) != nullptr;
-				  } else if (vendor == WIOKit::VendorID::ATIAMD && (code == WIOKit::ClassCode::DisplayController || code == WIOKit::ClassCode::VGAController)) {
-					DBGLOG("dev", "found AMD iGPU device %s", safeString(name));
+			} else if (vendor == WIOKit::VendorID::ATIAMD && (code == WIOKit::ClassCode::DisplayController || code == WIOKit::ClassCode::VGAController)) {
+				uint32_t dev = 0;
+				WIOKit::getOSDataValue(obj, "device-id", dev);
+				dev = (dev & 0xFF00);
+				if ((dev == 0x1600 || dev == 1500) || (dev == 0x9800 || dev == 0x1300) || (dev == 0x9900 || dev == 0x9800) || dev == 0x9600) {
+					DBGLOG("dev", "found IGPU device %s", safeString(name));
 					videoBuiltin = obj;
+				}
 			} else if (code == WIOKit::ClassCode::HDADevice || code == WIOKit::ClassCode::HDAMmDevice) {
 				if (vendor == WIOKit::VendorID::Intel && name && (!strcmp(name, "HDAU") || !strcmp(name, "B0D3"))) {
 					DBGLOG("dev", "found HDAU device %s", safeString(name));

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -206,9 +206,9 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 				continue;
 
 			if (vendor == WIOKit::VendorID::Intel && (code == WIOKit::ClassCode::DisplayController || code == WIOKit::ClassCode::VGAController)) {
-					DBGLOG("dev", "found IGPU device %s", safeString(name));
-					videoBuiltin = obj;
-					requestedExternalSwitchOff |= videoBuiltin->getProperty(RequestedExternalSwitchOffName) != nullptr;
+				DBGLOG("dev", "found IGPU device %s", safeString(name));
+				videoBuiltin = obj;
+				requestedExternalSwitchOff |= videoBuiltin->getProperty(RequestedExternalSwitchOffName) != nullptr;
 			} else if (vendor == WIOKit::VendorID::ATIAMD && (code == WIOKit::ClassCode::DisplayController || code == WIOKit::ClassCode::VGAController)) {
 				uint32_t dev = 0;
 				WIOKit::getOSDataValue(obj, "device-id", dev);

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -213,7 +213,7 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 				uint32_t dev = 0;
 				WIOKit::getOSDataValue(obj, "device-id", dev);
 				dev = (dev & 0xFF00);
-				if ((dev == 0x1600 || dev == 1500) || (dev == 0x9800 || dev == 0x1300) || (dev == 0x9900 || dev == 0x9800) || dev == 0x9600) {
+				if ((dev == 0x1600 || dev == 1500) || (dev == 0x9800 || dev == 0x1300) || (dev == 0x9900 || dev == 0x9600)) {
 					DBGLOG("dev", "found IGPU device %s", safeString(name));
 					videoBuiltin = obj;
 				}

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -266,8 +266,8 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 								pcicode == WIOKit::ClassCode::XGAController) {
 								if (pcivendor == WIOKit::VendorID::ATIAMD) {
 									// The iGPU can live in places other than the root bridge.
-									// This can be seen on some of the newer devices.
-									// This may be why the older iGPUs had issues.
+									// This can be seen in Ryzen Mobile.
+									// This may be why the older iGPUs had issues, as the device seemingly lives under the root bridge on those platforms.
 									uint32_t dev = 0;
 									WIOKit::getOSDataValue(pciobj, "device-id", dev);
 									dev &= 0xFF00;

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -221,8 +221,8 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 					case GenericAMDSumo:
 					case GenericAMDKbMlCzStnWr:
 					case GenericAMDTrinity:
-					    DBGLOG("dev", "found IGPU device %s", safeString(name));
-					    videoBuiltin = obj;
+						DBGLOG("dev", "found IGPU device %s", safeString(name));
+						videoBuiltin = obj;
 						requestedExternalSwitchOff |= videoBuiltin->getProperty(RequestedExternalSwitchOffName) != nullptr;
 						break;
 					default:
@@ -280,7 +280,7 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 										case GenericAMDSumo:
 										case GenericAMDKbMlCzStnWr:
 										case GenericAMDTrinity:
-											DBGLOG("dev", "found IGPU device %s at %s (0x%x, by 0x%x)", safeString(pciobj->getName()), safeString(name), pcivendor, pcidev);
+											DBGLOG("dev", "found IGPU device %s at %s", safeString(pciobj->getName()), safeString(name));
 					    					videoBuiltin = pciobj;
 											requestedExternalSwitchOff |= videoBuiltin->getProperty(RequestedExternalSwitchOffName) != nullptr;
 											continue;

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -305,8 +305,7 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 					// AZAL audio devices cannot be descrete GPU devices.
 					// On several AMD platforms there is an IGPU, which makes AZAL be recognised as a descrete GPU/HDA pair.
 					// REF: https://github.com/acidanthera/Lilu/pull/65
-					// change v.video to videoBuiltin?
-					if (((v.audio && strcmp(v.audio->getName(), "AZAL") != 0) || !v.audio) && v.video) {
+					if (((v.audio && strcmp(v.audio->getName(), "AZAL") != 0) || !v.audio) && ) {
 						DBGLOG_COND(v.audio, "dev", "marking audio device as HDAU at %s", safeString(v.audio->getName()));
 						if (!videoExternal.push_back(v))
 							SYSLOG("dev", "failed to push video gpu");

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -269,7 +269,7 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 									// This can be seen on some of the newer devices.
 									// This may be why the older iGPUs had issues.
 									uint32_t dev = 0;
-									WIOKit::getOSDataValue(obj, "device-id", dev);
+									WIOKit::getOSDataValue(pciobj, "device-id", dev);
 									dev &= 0xFF00;
 									switch (dev) {
 										case GenericAMDKvGr:
@@ -280,7 +280,7 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 										case GenericAMDKbMlCzStnWr:
 										case GenericAMDTrinity:
 											DBGLOG("dev", "found IGPU device %s", safeString(name));
-					    					videoBuiltin = obj;
+					    					videoBuiltin = pciobj;
 											requestedExternalSwitchOff |= videoBuiltin->getProperty(RequestedExternalSwitchOffName) != nullptr;
 											continue;
 										default:

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -213,7 +213,7 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 				uint32_t dev = 0;
 				WIOKit::getOSDataValue(obj, "device-id", dev);
 				dev = (dev & 0xFF00);
-				if ((dev == 0x1600 || dev == 0x1500) || (dev == 0x9800 || dev == 0x1300) || (dev == 0x9900 || dev == 0x9600)) {
+				if ((dev == GenericAMDRnCznLcVghRmbRph || dev == GenericAMDRvPcBcPhn) || (dev == GenericAMDKbMlCzStnWr || dev == GenericAMDKvGr) || (dev == GenericAMDTrinity || dev == GenericAMDSumo) || dev == GenericAMDPhoenix2) {
 					DBGLOG("dev", "found IGPU device %s", safeString(name));
 					videoBuiltin = obj;
 				}

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -213,7 +213,7 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 				uint32_t dev = 0;
 				WIOKit::getOSDataValue(obj, "device-id", dev);
 				dev = (dev & 0xFF00);
-				if ((dev == 0x1600 || dev == 1500) || (dev == 0x9800 || dev == 0x1300) || (dev == 0x9900 || dev == 0x9600)) {
+				if ((dev == 0x1600 || dev == 0x1500) || (dev == 0x9800 || dev == 0x1300) || (dev == 0x9900 || dev == 0x9600)) {
 					DBGLOG("dev", "found IGPU device %s", safeString(name));
 					videoBuiltin = obj;
 				}

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -281,7 +281,7 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 										case GenericAMDKbMlCzStnWr:
 										case GenericAMDTrinity:
 											DBGLOG("dev", "found IGPU device %s at %s", safeString(pciobj->getName()), safeString(name));
-					    					videoBuiltin = pciobj;
+											videoBuiltin = pciobj;
 											requestedExternalSwitchOff |= videoBuiltin->getProperty(RequestedExternalSwitchOffName) != nullptr;
 											continue;
 										default:

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -206,9 +206,12 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 				continue;
 
 			if (vendor == WIOKit::VendorID::Intel && (code == WIOKit::ClassCode::DisplayController || code == WIOKit::ClassCode::VGAController)) {
-				DBGLOG("dev", "found IGPU device %s", safeString(name));
-				videoBuiltin = obj;
-				requestedExternalSwitchOff |= videoBuiltin->getProperty(RequestedExternalSwitchOffName) != nullptr;
+					DBGLOG("dev", "found IGPU device %s", safeString(name));
+					videoBuiltin = obj;
+					requestedExternalSwitchOff |= videoBuiltin->getProperty(RequestedExternalSwitchOffName) != nullptr;
+				  } else if (vendor == WIOKit::VendorID::ATIAMD && (code == WIOKit::ClassCode::DisplayController || code == WIOKit::ClassCode::VGAController)) {
+					DBGLOG("dev", "found AMD iGPU device %s", safeString(name));
+					videoBuiltin = obj;
 			} else if (code == WIOKit::ClassCode::HDADevice || code == WIOKit::ClassCode::HDAMmDevice) {
 				if (vendor == WIOKit::VendorID::Intel && name && (!strcmp(name, "HDAU") || !strcmp(name, "B0D3"))) {
 					DBGLOG("dev", "found HDAU device %s", safeString(name));
@@ -272,10 +275,6 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 						// To distinguish the devices we use audio card presence as a marker.
 						DBGLOG("dev", "marking audio device as HDEF at %s", safeString(v.audio->getName()));
 						audioBuiltinAnalog = v.audio;
-						
-						if (v.video && v.vendor == WIOKit::VendorID::ATIAMD) {
-							videoBuiltin = v.video;
-						}
 					}
 				}
 			}

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -268,10 +268,11 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 									// The iGPU can live in places other than the root bridge.
 									// This can be seen in Ryzen Mobile.
 									// This may be why the older iGPUs had issues, as the device seemingly lives under the root bridge on those platforms.
-									uint32_t dev = 0;
-									WIOKit::getOSDataValue(pciobj, "device-id", dev);
-									dev &= 0xFF00;
-									switch (dev) {
+									uint32_t pcidev = 0;
+									// change to read from PCI config space?
+									WIOKit::getOSDataValue(pciobj, "device-id", pcidev);
+									pcidev &= 0xFF00;
+									switch (pcidev) {
 										case GenericAMDKvGr:
 										case GenericAMDRvPcBcPhn:
 										case GenericAMDRnCznLcVghRmbRph:
@@ -279,7 +280,7 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 										case GenericAMDSumo:
 										case GenericAMDKbMlCzStnWr:
 										case GenericAMDTrinity:
-											DBGLOG("dev", "found IGPU device %s", safeString(name));
+											DBGLOG("dev", "found IGPU device %s at %s (0x%x, by 0x%x)", safeString(pciobj->getName()), safeString(name), pcivendor, pcidev);
 					    					videoBuiltin = pciobj;
 											requestedExternalSwitchOff |= videoBuiltin->getProperty(RequestedExternalSwitchOffName) != nullptr;
 											continue;
@@ -304,6 +305,7 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 					// AZAL audio devices cannot be descrete GPU devices.
 					// On several AMD platforms there is an IGPU, which makes AZAL be recognised as a descrete GPU/HDA pair.
 					// REF: https://github.com/acidanthera/Lilu/pull/65
+					// change v.video to videoBuiltin?
 					if (((v.audio && strcmp(v.audio->getName(), "AZAL") != 0) || !v.audio) && v.video) {
 						DBGLOG_COND(v.audio, "dev", "marking audio device as HDAU at %s", safeString(v.audio->getName()));
 						if (!videoExternal.push_back(v))

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -305,7 +305,7 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 					// AZAL audio devices cannot be descrete GPU devices.
 					// On several AMD platforms there is an IGPU, which makes AZAL be recognised as a descrete GPU/HDA pair.
 					// REF: https://github.com/acidanthera/Lilu/pull/65
-					if (((v.audio && strcmp(v.audio->getName(), "AZAL") != 0) || !v.audio) && ) {
+					if (((v.audio && strcmp(v.audio->getName(), "AZAL") != 0) || !v.audio) && v.video) {
 						DBGLOG_COND(v.audio, "dev", "marking audio device as HDAU at %s", safeString(v.audio->getName()));
 						if (!videoExternal.push_back(v))
 							SYSLOG("dev", "failed to push video gpu");


### PR DESCRIPTION
V2 as the last version broke iGPUs that aren't under the PCI Root Bridge.

~~Also, @vit9696 should line [309](https://github.com/Zormeister/Lilu/blob/master/Lilu/Sources/kern_devinfo.cpp#L309) be changed to check for `videoBuiltin` and not `v.video`?~~