### PR TITLE
Update DeviceID based AMD iGPU detection

### DIFF
--- a/Lilu/Headers/kern_devinfo.hpp
+++ b/Lilu/Headers/kern_devinfo.hpp
@@ -263,7 +263,7 @@ private:
 	 */
 	static constexpr uint32_t GenericAMDKbMlCzStnWr = 0x9800;
 
-    /**
+	/**
 	 * Van Gogh's other Device ID, specifically: 0x1435 rev 0xAE.
 	 */
 	static constexpr uint32_t GenericAMDVanGogh2 = 0x1400;

--- a/Lilu/Headers/kern_devinfo.hpp
+++ b/Lilu/Headers/kern_devinfo.hpp
@@ -263,8 +263,13 @@ private:
 	 */
 	static constexpr uint32_t GenericAMDKbMlCzStnWr = 0x9800;
 
+    /**
+	 * Van Gogh's other Device ID, specifically: 0x1435 rev 0xAE.
+	 */
+	static constexpr uint32_t GenericAMDVanGogh2 = 0x1400;
+
 	/**
-	 * Raven/Raven2, Picasso, Barcelo, Phoenix & Phoenix 2 (?)
+	 * Raven/Raven2, Picasso, Barcelo, Phoenix, Phoenix 2 (possibly Hawk Point)  & Strix (0x150E)
 	 */
 	static constexpr uint32_t GenericAMDRvPcBcPhn = 0x1500;
 

--- a/Lilu/Sources/kern_devinfo.cpp
+++ b/Lilu/Sources/kern_devinfo.cpp
@@ -190,6 +190,7 @@ bool DeviceInfo::checkForAndSetAMDiGPU(IORegistryEntry *obj) {
 	dev &= 0xFF00;
 	switch (dev) {
 		case GenericAMDKvGr:
+		case GenericAMDVanGogh2:
 		case GenericAMDRvPcBcPhn:
 		case GenericAMDRnCznLcVghRmbRph:
 		case GenericAMDPhoenix2:
@@ -270,8 +271,8 @@ void DeviceInfo::grabDevicesFromPciRoot(IORegistryEntry *pciRoot) {
 								pcicode == WIOKit::ClassCode::XGAController) {
 								if (pcivendor == WIOKit::VendorID::ATIAMD) {
 									// The iGPU can live in places other than the root bridge.
-									// This can be seen in Ryzen Mobile.
-									// This may be why the older iGPUs had issues, as the device seemingly lives under the root bridge on those platforms.
+									// This can be seen in Ryzen Mobile and newer.
+									// This is why the older iGPUs had issues, as the device lives under the root bridge on those platforms.
 									if (checkForAndSetAMDiGPU(pciobj)) {
 										continue;
 									}


### PR DESCRIPTION
Adds in `0x1400` which can be found in the Van Gogh APU

Also adds in another iGPU to the list for `0x1500`