### PR TITLE
Add constants for macOS 26/Tahoe support

### DIFF
--- a/Lilu/Headers/kern_util.hpp
+++ b/Lilu/Headers/kern_util.hpp
@@ -396,7 +396,7 @@ enum KernelVersion {
 	Ventura       = 22,
 	Sonoma        = 23,
 	Sequoia       = 24,
-	Sixteen       = 25,
+	Tahoe         = 25,
 };
 
 /**

--- a/Lilu/Headers/kern_util.hpp
+++ b/Lilu/Headers/kern_util.hpp
@@ -396,6 +396,7 @@ enum KernelVersion {
 	Ventura       = 22,
 	Sonoma        = 23,
 	Sequoia       = 24,
+	Sixteen       = 25,
 };
 
 /**

--- a/Lilu/PrivateHeaders/kern_config.hpp
+++ b/Lilu/PrivateHeaders/kern_config.hpp
@@ -58,7 +58,7 @@ private:
 	/**
 	 * Maxmimum supported kernel version
 	 */
-	static constexpr KernelVersion maxKernel {KernelVersion::Sixteen};
+	static constexpr KernelVersion maxKernel {KernelVersion::Tahoe};
 
 	/**
 	 *  Set once the arguments are parsed

--- a/Lilu/PrivateHeaders/kern_config.hpp
+++ b/Lilu/PrivateHeaders/kern_config.hpp
@@ -56,7 +56,7 @@ private:
 	static constexpr KernelVersion minKernel {KernelVersion::Tiger};
 
 	/**
-	 * Maxmimum supported kernel version
+	 * Maximum supported kernel version
 	 */
 	static constexpr KernelVersion maxKernel {KernelVersion::Tahoe};
 

--- a/Lilu/PrivateHeaders/kern_config.hpp
+++ b/Lilu/PrivateHeaders/kern_config.hpp
@@ -58,7 +58,7 @@ private:
 	/**
 	 * Maxmimum supported kernel version
 	 */
-	static constexpr KernelVersion maxKernel {KernelVersion::Sequoia};
+	static constexpr KernelVersion maxKernel {KernelVersion::Sixteen};
 
 	/**
 	 *  Set once the arguments are parsed


### PR DESCRIPTION
So, after we finally got a name for macOS 26, hoping the name will be the one we have now (Tahoe), and knowing that it will most likely support Intel, I've already updated Lilu with the new constants in order to allow kexts to be compatible with macOS 26 from the very start, and without the use of -lilubetaall, since some kexts like NootedRed don't work even with it and need to be updated. We're still uncertain about both the name and XNU version of macOS 26, so I'd recommend merging this on June 9th after DB1 releases.

EDIT: I guessed both the name and XNU version. This kext is working.