### PR TITLE
Fix address slot overruns causing AMDSupport panics

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 Lilu Changelog
 ==============
+#### v1.7.2
+- Fixed AMDSupport lockups & panics in macOS 26
+
 #### v1.7.1
 - Allow loading on macOS 26 without `-lilubetaall`, thanks @AlfCraft07
 

--- a/Lilu/Headers/kern_mach.hpp
+++ b/Lilu/Headers/kern_mach.hpp
@@ -187,7 +187,7 @@ class MachInfo {
 	 *
 	 *  @return KERN_SUCCESS if found
 	 */
-	kern_return_t kcGetAddressSlots(mach_header_64 *hdr, segment_command_64 *segment);
+	kern_return_t getAddressSlots(mach_header_64 *hdr, segment_command_64 *segment);
 	
 public:
 

--- a/Lilu/Headers/kern_mach.hpp
+++ b/Lilu/Headers/kern_mach.hpp
@@ -182,6 +182,13 @@ class MachInfo {
 	 */
 	kern_return_t initFromMemory();
 
+	/**
+	 * 	Resolve for empty space between segments for medium jumps
+	 *
+	 *  @return KERN_SUCCESS if found
+	 */
+	kern_return_t kcGetAddressSlots(mach_header_64 *hdr, segment_command_64 *segment);
+	
 public:
 
 	/**

--- a/Lilu/Sources/kern_mach.cpp
+++ b/Lilu/Sources/kern_mach.cpp
@@ -897,7 +897,7 @@ kern_return_t MachInfo::kcGetRunningAddresses(mach_vm_address_t slide) {
 		size_t tmpSectSize;
 		
 		findSectionBounds((void *) running_mh, memory_size, tmpSeg, tmpSect, tmpSectPtr, tmpSectSize, "__TEXT", "__text");
-		address_slots = reinterpret_cast<mach_vm_address_t>(inner + 1) + inner->sizeofcmds;
+		address_slots = reinterpret_cast<mach_vm_address_t>(inner + 1) + inner->sizeofcmds + sizeof(*inner);
 		address_slots_end = (mach_vm_address_t) tmpSectPtr;
 
 		DBGLOG("mach", "activating slots for %s in " PRIKADDR " - " PRIKADDR, objectId, CASTKADDR(address_slots), CASTKADDR(address_slots_end));

--- a/Lilu/Sources/kern_mach.cpp
+++ b/Lilu/Sources/kern_mach.cpp
@@ -813,12 +813,12 @@ kern_return_t MachInfo::kcGetAddressSlots(mach_header_64 *hdr, segment_command_6
 	}
 	
 	// First space is between the mach load commands and first section (usually __text)
-	if (section->addr < reinterpret_cast<mach_vm_address_t>(hdr) + sizeof(*hdr)) {
+	if (section->addr < reinterpret_cast<mach_vm_address_t>(hdr) + sizeof(*hdr) + hdr->sizeofcmds) {
 		SYSLOG("mach", "Invalid section address for address slots");
 		return KERN_FAILURE;
 	}
 	
-	address_slots = reinterpret_cast<mach_vm_address_t>(hdr) + sizeof(*hdr);
+	address_slots = reinterpret_cast<mach_vm_address_t>(hdr) + sizeof(*hdr) + hdr->sizeofcmds;
 	address_slots_end = section->addr;
 
 	// Find last section

--- a/Lilu/Sources/kern_mach.cpp
+++ b/Lilu/Sources/kern_mach.cpp
@@ -620,9 +620,11 @@ void MachInfo::findSectionBounds(void *ptr, size_t sourceSize, vm_address_t &vms
 
 				for (uint32_t sno = 0; sno < scmd->nsects; sno++) {
 					if (!strncmp(sect->sectname, sectionName, sizeof(sect->sectname))) {
-						auto sptr = static_cast<uint8_t *>(ptr) + sect->offset;
+						auto sptr = reinterpret_cast<uint8_t *>(sect->addr);
+						SYSLOG("mach", "ptr: " PRIKADDR " vmaddr: " PRIKADDR, CASTKADDR(ptr), CASTKADDR(sect->addr));
 						if (sptr + sect->size > endaddr) {
-							SYSLOG("mach", "found section %s size %llu in segment %u is invalid (" PRIKADDR " + %llx > " PRIKADDR, sectionName, sect->size, sno, CASTKADDR(sptr), sect->size, CASTKADDR(endaddr));
+							SYSLOG("mach", "found section %s size %llu in segment %u is invalid (" PRIKADDR " + 0x%llx > " PRIKADDR, sectionName, sect->size, sno, CASTKADDR(sptr), sect->size, CASTKADDR(endaddr));
+							SYSLOG("mach", "ptr: " PRIKADDR " vmaddr: " PRIKADDR, CASTKADDR(ptr), CASTKADDR(sect->addr));
 							return;
 						}
 						vmsegment = (vm_address_t)scmd->vmaddr;

--- a/Lilu/Sources/kern_mach.cpp
+++ b/Lilu/Sources/kern_mach.cpp
@@ -802,6 +802,47 @@ uint8_t *MachInfo::findImage(const char *identifier, uint32_t &imageSize, mach_v
 	return nullptr;
 }
 
+kern_return_t MachInfo::kcGetAddressSlots(mach_header_64 *hdr, segment_command_64 *segment) {
+	auto section = reinterpret_cast<section_64 *>(segment + 1);
+	mach_vm_address_t last_slot_start = 0;
+	mach_vm_address_t last_slot_end = 0;
+	size_t idx = 0;
+	
+	if (segment->nsects == 0) {
+		return KERN_FAILURE;
+	}
+	
+	// First space is between the mach load commands and first section (usually __text)
+	if (section->addr < reinterpret_cast<mach_vm_address_t>(hdr) + sizeof(*hdr)) {
+		SYSLOG("mach", "Invalid section address for address slots");
+		return KERN_FAILURE;
+	}
+	
+	address_slots = reinterpret_cast<mach_vm_address_t>(hdr) + sizeof(*hdr);
+	address_slots_end = section->addr;
+
+	// Find last section
+	for (idx = 0; idx < segment->nsects - 1; section++, idx++) {}
+	
+	// Second potential space is between the last section and the end of the segment
+	last_slot_start = section->addr + section->size;
+	last_slot_end = segment->vmaddr + segment->vmsize;
+	
+	DBGLOG("mach", "Potential slots: " PRIKADDR " - " PRIKADDR " : " PRIKADDR " - " PRIKADDR,
+		   CASTKADDR(address_slots), CASTKADDR(address_slots_end),
+		   CASTKADDR(last_slot_start), CASTKADDR(last_slot_end));
+	
+	if (last_slot_start > segment->vmaddr &&
+		(last_slot_end - last_slot_start) > (address_slots_end - address_slots)) {
+		address_slots = last_slot_start;
+		address_slots_end = last_slot_end;
+	}
+	
+	DBGLOG("mach", "activating slots for %s in " PRIKADDR " - " PRIKADDR, objectId, CASTKADDR(address_slots), CASTKADDR(address_slots_end));
+	
+	return KERN_SUCCESS;
+}
+
 kern_return_t MachInfo::kcGetRunningAddresses(mach_vm_address_t slide) {
 #if defined (__i386__)
 	// KC is not supported on 32-bit.
@@ -847,8 +888,6 @@ kern_return_t MachInfo::kcGetRunningAddresses(mach_vm_address_t slide) {
 	DBGLOG("mach", "got nouveau mach-o for %s at " PRIKADDR, objectId, CASTKADDR(inner));
 
 	mach_vm_address_t last_addr = 0;
-	mach_vm_address_t text_addr = 0;
-	size_t text_size = 0;
 
 	auto addr = reinterpret_cast<uint8_t *>(inner) + sizeof(mach_header_64);
 	for (uint32_t i = 0; i < inner->ncmds; i++) {
@@ -858,17 +897,10 @@ kern_return_t MachInfo::kcGetRunningAddresses(mach_vm_address_t slide) {
 			auto segCmd = reinterpret_cast<segment_command_64 *>(loadCmd);
 			DBGLOG("mach", "%s has segment is %s from " PRIKADDR " to " PRIKADDR, objectId, segCmd->segname,
 				   CASTKADDR(segCmd->vmaddr), CASTKADDR(segCmd->vmaddr + segCmd->vmsize));
-			
-			// Save off __TEXT segment addresses so we can try and find blank space for address slots
-			if (!text_addr && !strncmp(segCmd->segname, "__TEXT", sizeof(segCmd->segname))) {
-				text_addr = segCmd->vmaddr;
-				text_size = segCmd->vmsize;
-				
-				// TODO: Move address slot stuff in here, maybe iterate over sections?
-				// Iterating here would mean I could remove modifications to findSectionBounds
-				// I would guess that the biggest gaps will be between the last section and next segment (__DATA)
-				// OR between mach header -> first section (__text) in the __TEXT segment
-				// So maybe iteration isn't necessary and we just check the two sections listed above?
+
+			// Try to find space for address slots in __TEXT segment
+			if (!strncmp(segCmd->segname, "__TEXT", sizeof(segCmd->segname)) && (slide || isKernel)) {
+				(void) kcGetAddressSlots(inner, segCmd);
 			}
 			
 			if (!sym_buf && !strncmp(segCmd->segname, "__LINKEDIT", sizeof(segCmd->segname))) {
@@ -906,37 +938,6 @@ kern_return_t MachInfo::kcGetRunningAddresses(mach_vm_address_t slide) {
 	prelink_slid = true;
 	running_mh = inner;
 	memory_size = (size_t)(last_addr - reinterpret_cast<mach_vm_address_t>(inner));
-	if (slide != 0 || isKernel) {
-		vm_address_t tmpSeg, tmpSect;
-		void *tmpSectPtr;
-		size_t tmpSectSize;
-		
-		findSectionBounds(reinterpret_cast<void *>(running_mh), memory_size, tmpSeg, tmpSect, tmpSectPtr, tmpSectSize, "__TEXT", "__text");
-		address_slots = reinterpret_cast<mach_vm_address_t>(inner) + sizeof(*inner) + inner->sizeofcmds;
-		address_slots_end = reinterpret_cast<mach_vm_address_t>(tmpSectPtr) - 1;
-		
-		if (!isKernel) {
-			findSectionBounds(reinterpret_cast<void *>(running_mh), memory_size, tmpSeg, tmpSect, tmpSectPtr, tmpSectSize, "__TEXT", "__const");
-			
-			// __const __TEXT -> end of __TEXT region
-			// TODO: This is not safe - should really be checking all the sections and do something smarter
-			// Good enough for testing AMDSupport though....
-			mach_vm_address_t new_start_addr = reinterpret_cast<mach_vm_address_t>(tmpSectPtr) + tmpSectSize;
-			mach_vm_address_t new_end_addr = text_addr + text_size;
-			
-			SYSLOG("mach", "Potential slots: " PRIKADDR " - " PRIKADDR " : " PRIKADDR " - " PRIKADDR,
-				   CASTKADDR(address_slots), CASTKADDR(address_slots_end),
-				   CASTKADDR(new_start_addr), CASTKADDR(new_end_addr));
-			
-			if (tmpSectPtr && (new_end_addr - new_start_addr) > (address_slots_end - address_slots)) {
-				address_slots = new_start_addr;
-				address_slots_end = new_end_addr;
-			}
-		}
-		
-
-		DBGLOG("mach", "activating slots for %s in " PRIKADDR " - " PRIKADDR, objectId, CASTKADDR(address_slots), CASTKADDR(address_slots_end));
-	}
 	return KERN_SUCCESS;
 
 #else

--- a/Lilu/Sources/kern_mach.cpp
+++ b/Lilu/Sources/kern_mach.cpp
@@ -620,7 +620,7 @@ void MachInfo::findSectionBounds(void *ptr, size_t sourceSize, vm_address_t &vms
 
 				for (uint32_t sno = 0; sno < scmd->nsects; sno++) {
 					if (!strncmp(sect->sectname, sectionName, sizeof(sect->sectname))) {
-						auto sptr = reinterpret_cast<uint8_t *>(sect->addr);
+						auto sptr = static_cast<uint8_t *>(ptr) + sect->offset;
 						if (sptr + sect->size > endaddr) {
 							SYSLOG("mach", "found section %s size %llu in segment %u is invalid", sectionName, sect->size, sno);
 							return;

--- a/Lilu/Sources/kern_mach.cpp
+++ b/Lilu/Sources/kern_mach.cpp
@@ -892,11 +892,13 @@ kern_return_t MachInfo::kcGetRunningAddresses(mach_vm_address_t slide) {
 	running_mh = inner;
 	memory_size = (size_t)(last_addr - reinterpret_cast<mach_vm_address_t>(inner));
 	if (slide != 0 || isKernel) {
+		vm_address_t tmpSeg, tmpSect;
+		void *tmpSectPtr;
+		size_t tmpSectSize;
+		
+		findSectionBounds((void *) running_mh, memory_size, tmpSeg, tmpSect, tmpSectPtr, tmpSectSize, "__TEXT", "__text");
 		address_slots = reinterpret_cast<mach_vm_address_t>(inner + 1) + inner->sizeofcmds;
-		address_slots_end = (address_slots + (PAGE_SIZE - 1)) & ~PAGE_SIZE;
-		while (*reinterpret_cast<uint32_t *>(address_slots_end) == 0) {
-			address_slots_end += PAGE_SIZE;
-		}
+		address_slots_end = (mach_vm_address_t) tmpSectPtr;
 
 		DBGLOG("mach", "activating slots for %s in " PRIKADDR " - " PRIKADDR, objectId, CASTKADDR(address_slots), CASTKADDR(address_slots_end));
 	}

--- a/Lilu/Sources/kern_mach.cpp
+++ b/Lilu/Sources/kern_mach.cpp
@@ -802,7 +802,7 @@ uint8_t *MachInfo::findImage(const char *identifier, uint32_t &imageSize, mach_v
 	return nullptr;
 }
 
-kern_return_t MachInfo::kcGetAddressSlots(mach_header_64 *hdr, segment_command_64 *segment) {
+kern_return_t MachInfo::getAddressSlots(mach_header_64 *hdr, segment_command_64 *segment) {
 	auto section = reinterpret_cast<section_64 *>(segment + 1);
 	mach_vm_address_t last_slot_start = 0;
 	mach_vm_address_t last_slot_end = 0;
@@ -900,7 +900,7 @@ kern_return_t MachInfo::kcGetRunningAddresses(mach_vm_address_t slide) {
 
 			// Try to find space for address slots in __TEXT segment
 			if (!strncmp(segCmd->segname, "__TEXT", sizeof(segCmd->segname)) && (slide || isKernel)) {
-				(void) kcGetAddressSlots(inner, segCmd);
+				(void) getAddressSlots(inner, segCmd);
 			}
 			
 			if (!sym_buf && !strncmp(segCmd->segname, "__LINKEDIT", sizeof(segCmd->segname))) {
@@ -998,6 +998,10 @@ kern_return_t MachInfo::getRunningAddresses(mach_vm_address_t slide, size_t size
 				if (!strncmp(segCmd->segname, "__TEXT", sizeof(segCmd->segname))) {
 					running_text_addr = segCmd->vmaddr;
 					running_mh = mh;
+
+#if defined(__x86_64__)
+					(void) getAddressSlots(mh, segCmd);
+#endif
 					break;
 				}
 #if defined(__i386__)
@@ -1038,14 +1042,6 @@ kern_return_t MachInfo::getRunningAddresses(mach_vm_address_t slide, size_t size
 		kaslr_slide_set = true;
 
 		DBGLOG("mach", "aslr/load slide is 0x%llx", kaslr_slide);
-				
-#if defined(__x86_64__)
-		address_slots = reinterpret_cast<mach_vm_address_t>(running_mh + 1) + running_mh->sizeofcmds;
-		address_slots_end = (address_slots + (PAGE_SIZE - 1)) & ~PAGE_SIZE;
-		while (*reinterpret_cast<uint32_t *>(address_slots_end) == 0) {
-			address_slots_end += PAGE_SIZE;
-		}
-#endif
 	} else {
 		SYSLOG("mach", "couldn't find the running addresses");
 		return KERN_FAILURE;

--- a/Lilu/Sources/kern_mach.cpp
+++ b/Lilu/Sources/kern_mach.cpp
@@ -621,10 +621,8 @@ void MachInfo::findSectionBounds(void *ptr, size_t sourceSize, vm_address_t &vms
 				for (uint32_t sno = 0; sno < scmd->nsects; sno++) {
 					if (!strncmp(sect->sectname, sectionName, sizeof(sect->sectname))) {
 						auto sptr = reinterpret_cast<uint8_t *>(sect->addr);
-						SYSLOG("mach", "ptr: " PRIKADDR " vmaddr: " PRIKADDR, CASTKADDR(ptr), CASTKADDR(sect->addr));
 						if (sptr + sect->size > endaddr) {
-							SYSLOG("mach", "found section %s size %llu in segment %u is invalid (" PRIKADDR " + 0x%llx > " PRIKADDR, sectionName, sect->size, sno, CASTKADDR(sptr), sect->size, CASTKADDR(endaddr));
-							SYSLOG("mach", "ptr: " PRIKADDR " vmaddr: " PRIKADDR, CASTKADDR(ptr), CASTKADDR(sect->addr));
+							SYSLOG("mach", "found section %s size %llu in segment %u is invalid", sectionName, sect->size, sno);
 							return;
 						}
 						vmsegment = (vm_address_t)scmd->vmaddr;
@@ -849,6 +847,8 @@ kern_return_t MachInfo::kcGetRunningAddresses(mach_vm_address_t slide) {
 	DBGLOG("mach", "got nouveau mach-o for %s at " PRIKADDR, objectId, CASTKADDR(inner));
 
 	mach_vm_address_t last_addr = 0;
+	mach_vm_address_t text_addr = 0;
+	size_t text_size = 0;
 
 	auto addr = reinterpret_cast<uint8_t *>(inner) + sizeof(mach_header_64);
 	for (uint32_t i = 0; i < inner->ncmds; i++) {
@@ -858,6 +858,19 @@ kern_return_t MachInfo::kcGetRunningAddresses(mach_vm_address_t slide) {
 			auto segCmd = reinterpret_cast<segment_command_64 *>(loadCmd);
 			DBGLOG("mach", "%s has segment is %s from " PRIKADDR " to " PRIKADDR, objectId, segCmd->segname,
 				   CASTKADDR(segCmd->vmaddr), CASTKADDR(segCmd->vmaddr + segCmd->vmsize));
+			
+			// Save off __TEXT segment addresses so we can try and find blank space for address slots
+			if (!text_addr && !strncmp(segCmd->segname, "__TEXT", sizeof(segCmd->segname))) {
+				text_addr = segCmd->vmaddr;
+				text_size = segCmd->vmsize;
+				
+				// TODO: Move address slot stuff in here, maybe iterate over sections?
+				// Iterating here would mean I could remove modifications to findSectionBounds
+				// I would guess that the biggest gaps will be between the last section and next segment (__DATA)
+				// OR between mach header -> first section (__text) in the __TEXT segment
+				// So maybe iteration isn't necessary and we just check the two sections listed above?
+			}
+			
 			if (!sym_buf && !strncmp(segCmd->segname, "__LINKEDIT", sizeof(segCmd->segname))) {
 				sym_buf = reinterpret_cast<uint8_t *>(segCmd->vmaddr);
 				sym_fileoff = segCmd->fileoff;
@@ -898,9 +911,29 @@ kern_return_t MachInfo::kcGetRunningAddresses(mach_vm_address_t slide) {
 		void *tmpSectPtr;
 		size_t tmpSectSize;
 		
-		findSectionBounds((void *) running_mh, memory_size, tmpSeg, tmpSect, tmpSectPtr, tmpSectSize, "__TEXT", "__text");
-		address_slots = reinterpret_cast<mach_vm_address_t>(inner + 1) + inner->sizeofcmds + sizeof(*inner);
-		address_slots_end = (mach_vm_address_t) tmpSectPtr;
+		findSectionBounds(reinterpret_cast<void *>(running_mh), memory_size, tmpSeg, tmpSect, tmpSectPtr, tmpSectSize, "__TEXT", "__text");
+		address_slots = reinterpret_cast<mach_vm_address_t>(inner) + sizeof(*inner) + inner->sizeofcmds;
+		address_slots_end = reinterpret_cast<mach_vm_address_t>(tmpSectPtr) - 1;
+		
+		if (!isKernel) {
+			findSectionBounds(reinterpret_cast<void *>(running_mh), memory_size, tmpSeg, tmpSect, tmpSectPtr, tmpSectSize, "__TEXT", "__const");
+			
+			// __const __TEXT -> end of __TEXT region
+			// TODO: This is not safe - should really be checking all the sections and do something smarter
+			// Good enough for testing AMDSupport though....
+			mach_vm_address_t new_start_addr = reinterpret_cast<mach_vm_address_t>(tmpSectPtr) + tmpSectSize;
+			mach_vm_address_t new_end_addr = text_addr + text_size;
+			
+			SYSLOG("mach", "Potential slots: " PRIKADDR " - " PRIKADDR " : " PRIKADDR " - " PRIKADDR,
+				   CASTKADDR(address_slots), CASTKADDR(address_slots_end),
+				   CASTKADDR(new_start_addr), CASTKADDR(new_end_addr));
+			
+			if (tmpSectPtr && (new_end_addr - new_start_addr) > (address_slots_end - address_slots)) {
+				address_slots = new_start_addr;
+				address_slots_end = new_end_addr;
+			}
+		}
+		
 
 		DBGLOG("mach", "activating slots for %s in " PRIKADDR " - " PRIKADDR, objectId, CASTKADDR(address_slots), CASTKADDR(address_slots_end));
 	}

--- a/Lilu/Sources/kern_mach.cpp
+++ b/Lilu/Sources/kern_mach.cpp
@@ -593,14 +593,14 @@ void MachInfo::findSectionBounds(void *ptr, size_t sourceSize, vm_address_t &vms
 					if (!strncmp(sect->sectname, sectionName, sizeof(sect->sectname))) {
 						auto sptr = static_cast<uint8_t *>(ptr) + sect->offset;
 						if (sptr + sect->size > endaddr) {
-							SYSLOG("mach", "found section %s size %u in segment %llu is invalid", sectionName, sno, (uint64_t)vmsegment);
+							SYSLOG("mach", "found section %s size %u in segment %u is invalid", sectionName, sect->size, sno);
 							return;
 						}
 						vmsegment = scmd->vmaddr;
 						vmsection = sect->addr;
 						sectionptr = sptr;
 						sectionSize = static_cast<size_t>(sect->size);
-						DBGLOG("mach", "found section %s size %u in segment %llu", sectionName, sno, (uint64_t)vmsegment);
+						DBGLOG("mach", "found section %s size %u in segment %u", sectionName, sect->size, sno);
 						return;
 					}
 
@@ -622,14 +622,14 @@ void MachInfo::findSectionBounds(void *ptr, size_t sourceSize, vm_address_t &vms
 					if (!strncmp(sect->sectname, sectionName, sizeof(sect->sectname))) {
 						auto sptr = static_cast<uint8_t *>(ptr) + sect->offset;
 						if (sptr + sect->size > endaddr) {
-							SYSLOG("mach", "found section %s size %u in segment %llu is invalid", sectionName, sno, (uint64_t)vmsegment);
+							SYSLOG("mach", "found section %s size %llu in segment %u is invalid (" PRIKADDR " + %llx > " PRIKADDR, sectionName, sect->size, sno, CASTKADDR(sptr), sect->size, CASTKADDR(endaddr));
 							return;
 						}
 						vmsegment = (vm_address_t)scmd->vmaddr;
 						vmsection = (vm_address_t)sect->addr;
 						sectionptr = sptr;
 						sectionSize = static_cast<size_t>(sect->size);
-						DBGLOG("mach", "found section %s size %u in segment %llu", sectionName, sno, (uint64_t)vmsegment);
+						DBGLOG("mach", "found section %s size %llu in segment %u", sectionName, sect->size, sno);
 						return;
 					}
 


### PR DESCRIPTION
EDIT: Should be good to go now

The address slot functionality assumed that the following text would be aligned on page boundaries after the macho header. This isn't the case for kexts though, with AMDSupport in Tahoe only having ~16 bytes of space between the header and first section within the __TEXT segment. Lilu would overwrite __cxx_global_var_init (first function in the __text section of the __TEXT segment) with the patched addresses, causing panics as shown below (Thanks @ParaDoX1994):
![IMG_3254](https://github.com/user-attachments/assets/d135443d-d37d-4a55-b8ba-788a36a3a09f)

> [   70.666538]: Lilu   patcher: @ (DBG) newly loaded kext is 0xFFFFFF7FA00B2000 and its name is com.apple.kext.AMDSupport (start func is 0xFFFFFF7FA013E042)
[   70.666546]: Lilu   patcher: @ (DBG) caught the right kext com.apple.kext.AMDSupport at 0xFFFFFF7FA00B2000, invoking handler
[   70.666555]: Lilu      mach: @ (DBG) got nouveau mach-o for com.apple.kext.AMDSupport at 0xFFFFFF7FA00B2000
[   70.666563]: Lilu      mach: @ (DBG) com.apple.kext.AMDSupport has segment is __TEXT from 0xFFFFFF7FA00B2000 to 0xFFFFFF7FA0178000
[   70.666570]: Lilu      mach: @ (DBG) com.apple.kext.AMDSupport has segment is __DATA from 0xFFFFFF7FA0178000 to 0xFFFFFF7FA019D000
[   70.666577]: Lilu      mach: @ (DBG) com.apple.kext.AMDSupport has segment is __DATA_CONST from 0xFFFFFF7FA019D000 to 0xFFFFFF7FA019F000
[   70.666584]: Lilu      mach: @ (DBG) com.apple.kext.AMDSupport has segment is __LINKEDIT from 0xFFFFFF7FA0BF0000 to 0xFFFFFF7FA10B14C9
[   70.666593]: Lilu      mach: @ (DBG) found section __text size 738858 in segment 0
[   70.666600]: Lilu      mach: @ (DBG) found section __const size 17568 in segment 2
[   70.666608]: Lilu      mach: @ Potential slots: 0xFFFFFF7FA00B25F0 - 0xFFFFFF7FA00B25FF : 0xFFFFFF7FA01772A0 - 0xFFFFFF7FA0178000
[   70.666615]: Lilu      mach: @ (DBG) activating slots for com.apple.kext.AMDSupport in 0xFFFFFF7FA01772A0 - 0xFFFFFF7FA0178000


There is two parts to this PR -
1) Fixing the end bound for address slots. I just grab the first section within the __TEXT segment and use that as the upper boundary for the address slots. This works but I think runs into the issues that were trying to be solved [here](https://github.com/acidanthera/Lilu/commit/bba464272a3599f064b11ef197b4d769ce00df92#diff-4fd72f122aab145b70d06ea25147fd2dc6e5b23f7c8a1caca2a07ce9c04ea8e7R423-R427) (in AMDSupport funnily enough)
2) Finding more free space to use for the addresses as AMDSupport still panics if you use the 14 byte patches. I've tried using the space between the last section and the end of the __TEXT segment ~~but it is currently causing panics on my system and I haven't had a ton of time to debug~~.

This is related to both https://github.com/acidanthera/WhateverGreen/pull/126 and https://github.com/acidanthera/WhateverGreen/pull/124